### PR TITLE
A more universal dark mode

### DIFF
--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -13,12 +13,14 @@
   "default_locale": "en",
   "permissions": [
       "webNavigation",
-      "https://canvas.vt.edu/*"
+      "https://canvas.vt.edu/*",
+      "https://*.instructure.com/*"
   ],
   "content_scripts": [
     {
       "matches": [
-        "https://canvas.vt.edu/*"
+        "https://canvas.vt.edu/*",
+        "https://*.instructure.com*"
       ],
       "css":[
           "css/styles.css"

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -20,7 +20,7 @@
     {
       "matches": [
         "https://canvas.vt.edu/*",
-        "https://*.instructure.com*"
+        "https://*.instructure.com/*"
       ],
       "css":[
           "css/styles.css"


### PR DESCRIPTION
In `manifest.json`, I've added the general Instructure link, so the Chrome extension works on any Canvas website with the instructure.com domain. Many schools use the format `insert-school-name-here.instructure.com`. I hope this helps!