### PR TITLE
Added VU canvas URL to manifest content scripts

### DIFF
--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -130,7 +130,9 @@
         "https://lms.pps.net/*",
         "https://uzemoys.ogu.edu.tr/*",
         "https://canvas.santarosa.edu/*",
-        "https://bcportalguard.butte.edu/*"
+        "https://bcportalguard.butte.edu/*",
+        "https://*.canvas.vu.nl/*",
+        "https://*.canvas.login.vu.nl/*"
       ],
       "css":[
           "css/styles.css"


### PR DESCRIPTION
Added VU (Vrije Universiteit)'s Canvas URL to manifest content scripts.

VU is one of the two universities located in Amsterdam, NL. I've verified that the URLs work. Strangely they use a different subdomain for the login page. I've added that one also.

I've noticed there are some areas still appear white (such as discussions and the calendar overview), I'll try and fix those in a different pull request, since they probably aren't only related to VU's canvas.