### PR TITLE
Added Stirling Uni URL and added missing comma

### DIFF
--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -220,7 +220,7 @@
         "https://mycanvas.mohawkcollege.ca/*",
         "https://canvas.park.edu/*",
         "https://learn.irvingisd.net/*",
-        "https://courses.ecu.edu.au/*"
+        "https://courses.ecu.edu.au/*",
         "https://canvas.msstate.edu/*",
         "https://canvas.stir.ac.uk/*"
       ],

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -222,6 +222,7 @@
         "https://learn.irvingisd.net/*",
         "https://courses.ecu.edu.au/*"
         "https://canvas.msstate.edu/*",
+        "https://canvas.stir.ac.uk/*"
       ],
       "css":[
           "css/styles.css"


### PR DESCRIPTION
Added the Stirling Uni URL and added a comma which was missing from a couple of lines above
![image](https://user-images.githubusercontent.com/25351253/189642535-00e14476-0b44-453b-b945-0eb548e20812.png)
