### PR TITLE
Code friendly theme

### DIFF
--- a/plugin/css/styles.css
+++ b/plugin/css/styles.css
@@ -181,3 +181,7 @@ a {
 .message-list .date, .ToDoSidebarItem__Info > ul > li {
     color: #7b7b7b !important;
 }
+
+code{
+    color: lightcyan !important;
+}

--- a/plugin/css/styles.css
+++ b/plugin/css/styles.css
@@ -185,3 +185,8 @@ a {
 code{
     color: lightcyan !important;
 }
+
+.answer_label pre{
+    background-color: #5d5d5d !important;
+    border: none !important;
+}

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -220,8 +220,8 @@
         "https://mycanvas.mohawkcollege.ca/*",
         "https://canvas.park.edu/*",
         "https://learn.irvingisd.net/*",
-        "https://courses.ecu.edu.au/*"
-        "https://canvas.msstate.edu/*",
+        "https://courses.ecu.edu.au/*",
+        "https://canvas.msstate.edu/*"
       ],
       "css":[
           "css/styles.css"


### PR DESCRIPTION
The current font color for code text is red, and it makes it challenging to read. I've changed it to a light cyan color in CSS. This patch also fixes quiz answers showing up with white code text on a white background.

Before:
<img width="805" alt="Screen Shot 2022-09-16 at 9 15 45 PM" src="https://user-images.githubusercontent.com/97067823/190842818-6b527aed-d04e-4cb5-9810-1342e9fa9e63.png">

After:
<img width="913" alt="Screen Shot 2022-09-16 at 9 21 32 PM" src="https://user-images.githubusercontent.com/97067823/190842820-87ab26fa-ab29-4b4f-8d70-f30c14a0ed9d.png">