### PR TITLE
Improve Contrast on Canvas Quizzes

### DIFF
--- a/plugin/css/styles.css
+++ b/plugin/css/styles.css
@@ -60,10 +60,6 @@ a {
     text-decoration: none !important;
 }
 
-.display_question [style] {
-    color: #fff !important;
-}
-
 .status-description, .title, .locked_title, .points_possible_display,  .ig-details__item
 , .name, h2, .comment, td, .score_value, .ic-Login__actions, .ic-Label{
     color: #C7CDD1 !important;
@@ -133,6 +129,10 @@ a {
 
 #questions.assessing, .question {
     background: none !important;
+}
+
+.display_question [style] {
+    color: #fff !important;
 }
 
 .pinned-discussions-v2__wrapper, .unpinned-discussions-v2__wrapper, .ic-discussion-row,

--- a/plugin/css/styles.css
+++ b/plugin/css/styles.css
@@ -60,6 +60,9 @@ a {
     text-decoration: none !important;
 }
 
+.display_question [style] {
+    color: white !important;
+}
 
 .status-description, .title, .locked_title, .points_possible_display,  .ig-details__item
 , .name, h2, .comment, td, .score_value, .ic-Login__actions, .ic-Label{

--- a/plugin/css/styles.css
+++ b/plugin/css/styles.css
@@ -61,7 +61,7 @@ a {
 }
 
 .display_question [style] {
-    color: white !important;
+    color: #fff !important;
 }
 
 .status-description, .title, .locked_title, .points_possible_display,  .ig-details__item


### PR DESCRIPTION
Canvas quizzes were unusable in Dark Mode for me because I couldn't see the multiple choice questions. They were black font on a black background as seen here:

![Screenshot 2024-03-10 at 1 07 41 PM](https://github.com/DeGrandis/canvas-dark-mode/assets/34797145/7e1988e6-615d-4aa9-bb67-217740eca402)

I simply updated the font of the display_question elements to be white.

![Screenshot 2024-03-10 at 2 38 01 PM](https://github.com/DeGrandis/canvas-dark-mode/assets/34797145/5bc384ef-4638-4e9f-84d4-16bbb86063fb)

I was only able to test on my own school's (CU Boulder) Canvas since I don't have access to other systems. 