### PR TITLE
Add Swedish Universities to Canvas Dark Mode list

### DIFF
--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -225,7 +225,9 @@
         "https://canvas.kdg.be/*",
         "https://canvas.liverpool.ac.uk/*",
         "https://canvas.moravian.edu/*",
-        "https://canvas-prod.ccsnh.edu/*"
+        "https://canvas-prod.ccsnh.edu/*",
+        "https://canvas.du.se/*",
+        "https://canvas.kth.se/*"
       ],
       "css":[
           "css/styles.css"


### PR DESCRIPTION
I added canvas.du.se and canvas.kth.se