### PR TITLE
Add WileyPLUS & Berklee College of Music

### DIFF
--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -225,7 +225,8 @@
         "https://canvas.kdg.be/*",
         "https://canvas.liverpool.ac.uk/*",
         "https://canvas.moravian.edu/*",
-        "https://canvas-prod.ccsnh.edu/*"
+        "https://canvas-prod.ccsnh.edu/*",
+        "https://learn.wileyplus.com/*"
       ],
       "css":[
           "css/styles.css"

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -226,7 +226,9 @@
         "https://canvas.liverpool.ac.uk/*",
         "https://canvas.moravian.edu/*",
         "https://canvas-prod.ccsnh.edu/*",
-        "https://learn.wileyplus.com/*"
+        "https://learn.wileyplus.com/*",
+        "https://canvas.berklee.edu/*",
+        "https://bocce.online.berklee.edu/*"
       ],
       "css":[
           "css/styles.css"


### PR DESCRIPTION
added WileyPLUS (learn.wileyplus.com)
added Berklee campus (canvas.berklee.edu)

added Berklee Online (bocce.online.berklee.edu) – For some reason, only the UI changes but not the course content, so when there's text to read inside the LMS, it's all still black text on a white background. There's no issues that prevent usability though, as discussions, submitting assignments, and reading the course content never has white-on-white or black-on-black. I think Berklee Online might use a weird fork of Canvas? Either way, a partial dark-mode is better than no dark mode. 